### PR TITLE
Stable/v1.8.x

### DIFF
--- a/project_name/requirements/base.txt
+++ b/project_name/requirements/base.txt
@@ -1,7 +1,7 @@
-Django==1.8.6
+Django==1.8.8
 # Postgres
 psycopg2==2.6.1
 # Redis Cache
-redis==2.10.3
-django-redis-cache==1.5.3
+redis==2.10.5
+django-redis-cache==1.6.5
 hiredis==0.2.0

--- a/project_name/requirements/base.txt
+++ b/project_name/requirements/base.txt
@@ -1,4 +1,4 @@
-Django==1.8.4
+Django==1.8.6
 # Postgres
 psycopg2==2.6.1
 # Redis Cache

--- a/project_name/settings/aws.py
+++ b/project_name/settings/aws.py
@@ -1,6 +1,12 @@
 from .base import *
 from logging.config import dictConfig
 
+# SECURITY WARNING: keep the secret key used in production secret!
+SECRET_KEY = SECURE_SETTINGS['django_secret_key']
+
+# SECURITY WARNING: don't run with debug turned on in production!
+DEBUG = SECURE_SETTINGS.get('enable_debug', False)
+
 # tlt hostnames
 ALLOWED_HOSTS = ['.tlt.harvard.edu']
 

--- a/project_name/settings/aws.py
+++ b/project_name/settings/aws.py
@@ -5,7 +5,7 @@ from logging.config import dictConfig
 SECRET_KEY = SECURE_SETTINGS['django_secret_key']
 
 # SECURITY WARNING: don't run with debug turned on in production!
-DEBUG = SECURE_SETTINGS.get('enable_debug', False)
+DEBUG = SECURE_SETTINGS['enable_debug']
 
 # tlt hostnames
 ALLOWED_HOSTS = ['.tlt.harvard.edu']

--- a/project_name/settings/base.py
+++ b/project_name/settings/base.py
@@ -16,12 +16,6 @@ from .secure import SECURE_SETTINGS
 # the project root
 BASE_DIR = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 
-# SECURITY WARNING: keep the secret key used in production secret!
-SECRET_KEY = SECURE_SETTINGS.get('django_secret_key', 'changeme')
-
-# SECURITY WARNING: don't run with debug turned on in production!
-DEBUG = SECURE_SETTINGS.get('enable_debug', False)
-
 # Application definition
 
 INSTALLED_APPS = [
@@ -65,7 +59,6 @@ TEMPLATES = [
                 'django.contrib.auth.context_processors.auth',
                 'django.contrib.messages.context_processors.messages',
             ],
-            'debug': DEBUG,
         },
     },
 ]

--- a/project_name/settings/local.py
+++ b/project_name/settings/local.py
@@ -1,7 +1,11 @@
 from .base import *
 from logging.config import dictConfig
 
+DEBUG = True
+
 ALLOWED_HOSTS = ['*']
+
+SECRET_KEY = 'changeme'
 
 EMAIL_BACKEND = 'django.core.mail.backends.console.EmailBackend'
 

--- a/project_name/settings/local.py
+++ b/project_name/settings/local.py
@@ -5,7 +5,7 @@ DEBUG = True
 
 ALLOWED_HOSTS = ['*']
 
-SECRET_KEY = 'changeme'
+SECRET_KEY = '{{ secret_key }}'
 
 EMAIL_BACKEND = 'django.core.mail.backends.console.EmailBackend'
 


### PR DESCRIPTION
Declare SECRET_KEY in both local and aws settings file so that we can trigger an error during deployment if it's not set there. Similarly, set DEBUG explicitly to True in local settings and pull from environment vars in aws settings.  No need to set the debug key in TEMPLATES config since it defaults to the value of DEBUG.  Update Django version in requirements to 1.8.6 from 1.8.4.

@cmurtaugh 
@ekiczek 
